### PR TITLE
Add get function, dont print output during shell launch

### DIFF
--- a/zc
+++ b/zc
@@ -3,6 +3,7 @@ setopt localoptions extendedglob clobber
 function __zconvey_usage_zc() {
     __zconvey_pinfo2 "Sends specified commands to given (via ID or NAME) Zsh session"
     __zconvey_pinfo "Usage: zc {-i ID}|{-n NAME} [-q|--quiet] [-v|--verbose] [-h|--help] [-a|--ask] [-r|--raw] COMMAND ARGUMENT ..."
+    print -- "-g/--get                 - get ID of Zsh session"
     print -- "-h/--help                - this message"
     print -- "-i ID / --id ID          - ID (number) of Zsh session"
     print -- "-n NAME / --name NAME    - NAME of Zsh session"
@@ -13,10 +14,13 @@ function __zconvey_usage_zc() {
 }
 
 local -A opthash
-zparseopts -D -A opthash h -help q -quiet v -verbose i: -id: n: -name: a -ask r -raw || { __zconvey_usage_zc; return 1; }
+zparseopts -D -A opthash h -help q -quiet g -get v -verbose i: -id: n: -name: a -ask r -raw || { __zconvey_usage_zc; return 1; }
 
 integer have_id=0 have_name=0 verbose=0 quiet=0 ask=0 raw=0
 local id name
+
+# Get ID
+(( ${+opthash[-g]} + ${+opthash[--get]} )) && { zc-id; return 0; }
 
 # Help
 (( ${+opthash[-h]} + ${+opthash[--help]} )) && { __zconvey_usage_zc; return 0; }

--- a/zconvey.plugin.zsh
+++ b/zconvey.plugin.zsh
@@ -536,4 +536,6 @@ add-zsh-hook precmd __zconvey_precmd_hook
 zle -N zc-logo
 bindkey '^O^I' zc-logo
 
+zstyle ':zconvey:*' init_complete true
+
 # vim:ft=zsh

--- a/zconvey.plugin.zsh
+++ b/zconvey.plugin.zsh
@@ -42,6 +42,7 @@ typeset -gH ZCONVEY_RUN_SECONDS=$(( SECONDS + 4 ))
 typeset -gH ZCONVEY_SCHEDULE_ORIGIN
 typeset -gHa ZCONVEY_NNS
 command mkdir -p "$ZCONVEY_IO_DIR" "$ZCONVEY_LOCKS_DIR" "$ZCONVEY_NAMES_DIR" "$ZCONVEY_OTHER_DIR"
+zstyle ':zconvey:*' init_complete false
 
 #
 # Helper functions
@@ -133,6 +134,9 @@ function __zconvey_is_session_active() {
 
 function zc-id() {
     __zconvey_get_name_of_id "$ZCONVEY_ID"
+    if ! zstyle -T ':zconvey:*' init_complete; then
+        return
+    fi
     if [[ -z "$REPLY" ]]; then
         print "This Zshell's ID: \033[1;33m<${ZCONVEY_ID}>\033[0m (no name assigned)";
     else


### PR DESCRIPTION
hey, really cool project here. I made a quality of life improvement
I dont love getting output during shell launch, especially as powerlevel9k warns about it by default
So Ive hidden the shell output until zstyle ':zconvey:*' init_complete true (put it at the bottom of ~/.zshrc)
I also couldnt figure out how to get the name of the current session once that message has gone back in time, so I made a get id function to get current sessions ID
feel free to use - or not!